### PR TITLE
Enable CIDR and pool editing for OLVM networks

### DIFF
--- a/src/main/groovy/com/morpheus/olvm/OlvmCloudProvider.groovy
+++ b/src/main/groovy/com/morpheus/olvm/OlvmCloudProvider.groovy
@@ -179,25 +179,25 @@ class OlvmCloudProvider implements CloudProvider {
 	@Override
 	Collection<NetworkType> getNetworkTypes() {
 		Collection<NetworkType> networks = []
-		networks << new NetworkType(
-			code:'olvm-logical-network',
-			name:'OLVM Logical Network',
-			overlay:false,
-			creatable:false,
-			nameEditable:false,
-			cidrEditable:false,
-			dhcpServerEditable:false,
-			dnsEditable:false,
-			gatewayEditable:false,
-			ipv6Editable:false,
-			vlanIdEditable:false,
-			cidrRequired:true,
-			canAssignPool:false,
-			deletable:false,
-			hasNetworkServer:false,
-			hasCidr:true,
-			optionTypes:[]
-		)
+                networks << new NetworkType(
+                        code:'olvm-logical-network',
+                        name:'OLVM Logical Network',
+                        overlay:false,
+                        creatable:false,
+                        nameEditable:false,
+                        cidrEditable:true,
+                        dhcpServerEditable:false,
+                        dnsEditable:false,
+                        gatewayEditable:false,
+                        ipv6Editable:false,
+                        vlanIdEditable:false,
+                        cidrRequired:true,
+                        canAssignPool:true,
+                        deletable:false,
+                        hasNetworkServer:false,
+                        hasCidr:true,
+                        optionTypes:[]
+                )
 		return networks
 	}
 


### PR DESCRIPTION
## Summary
- allow CIDR editing and pool assignment when OLVM networks are synced

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6853a2cef5c4832aa399033730878040